### PR TITLE
[README.md] Reference Apache licence at SPDX

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ These properties are maintained by BSI. Feel free to open an issue in this sourc
 
 © Copyright 2024-2025 German Federal Office for Information Security (BSI)
 
-Licensed under [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).
+Licensed under [Apache License 2.0](https://spdx.org/licenses/Apache-2.0.html).


### PR DESCRIPTION
… instead of at Apache.org, because:
- Use HTTPS link instead of HTTP
- SPDX.org is *the* instance for referencing OSS licenses in the realm of SBOMs.  Hence this taxonomy should rather utilise licence references provided by SPDX.org.
- The original licence link is prominently provided twice (plus the corresponding link to OSI's licence list) for every licence SPDX.org lists.  I.e. the link originally used here is now provided twice on the target web page.