### PR TITLE
Adapting taxonomy to publication of BSI TR-03183-2 v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# BSI CycloneDX Property Taxonomy, v0.1.1
+# BSI CycloneDX Property Taxonomy, v0.1.2
 
 This is the [BSI](https://bsi.de/EN) (German Federal Office for Information Security) property taxonomy for [CycloneDX](https://cyclonedx.org/).
 
-This taxonomy is based on **BSI TR-03183-2 v2.0.0**, which is available at <https://www.bsi.bund.de/dok/TR-03183-en>.
+This taxonomy is based on **BSI TR-03183-2 v2.1.0**, which is available at <https://www.bsi.bund.de/dok/TR-03183-en>.
 
 For more information about CycloneDX property taxonomies, see [CycloneDX documentation](https://github.com/CycloneDX/cyclonedx-property-taxonomy).
 
@@ -18,11 +18,12 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 
 | Property | Description |
 | --- | --- |
-| **`bsi:component:executable`** | A flag indicating whether the component is executable; possible values are `executable` and `non-executable`; see also section 5.2.2 of **BSI TR-03183-2 v2.0.0**. For additional explanation see section 8.1.3 of **BSI TR-03183-2 v2.0.0**.<br />Only valid for use in `components[]/properties` and `metadata/component/properties`. MUST occur exactly once per component. |
-| **`bsi:component:archive`** | A flag indicating whether the component is an archive; possible values are `archive` and `no archive`; see also section 5.2.2 of **BSI TR-03183-2 v2.0.0**. For additional explanation see section 8.1.4 of **BSI TR-03183-2 v2.0.0**.<br />Only valid for use in `components[]/properties` and `metadata/component/properties`. MUST occur exactly once per component. |
-| **`bsi:component:structured`** | A flag indicating whether the component is a structured file; i.e. metadata of the contents is still present (see section 3.2.1); possible values are `structured` and `unstructured`; see also section 5.2.2 of **BSI TR-03183-2 v2.0.0**. If a component contains both structured and unstructured parts the value `structured` MUST be used. For additional explanation see section 8.1.5 of **BSI TR-03183-2 v2.0.0**.<br />Only valid for use in `components[]/properties` and `metadata/component/properties`. MUST occur exactly once per component. |
-| **`bsi:component:filename`** | A field providing the actual filename of the component (i.e. not its path); see also section 5.2.2 of BSI-TR-03183-2 v2.0.0. For additional explanation see section 3.2.1 of **BSI TR-03183-2 v2.0.0**.<br />Only valid for use in `components[]/properties` and `metadata/component/properties`. MUST occur at most once per component. |
-| **`bsi:component:associatedLicences`** | A field providing the associated licence(s) of the component as a single licence identifier or licence expression from the perspective of the SBOM creator; see also section 5.2.2 of **BSI TR-03183-2 v2.0.0**. For additional explanation see sections 6.1 and 8.1.9 of **BSI TR-03183-2 v2.0.0**.<br />Only valid for use in `components[]/properties` and `metadata/component/properties`. MUST occur exactly once per component. |
+| **`bsi:component:executable`** | A flag indicating whether the component is executable; possible values are `executable` and `non-executable`; see also section 5.2.2 of **BSI TR-03183-2 v2.1.0**. For additional explanation see section 8.1.4 of **BSI TR-03183-2 v2.1.0**.<br />Only valid for use in `components[]/properties` and `metadata/component/properties`. MUST occur exactly once per component. |
+| **`bsi:component:archive`** | A flag indicating whether the component is an archive; possible values are `archive` and `no archive`; see also section 5.2.2 of **BSI TR-03183-2 v2.1.0**. For additional explanation see section 8.1.5 of **BSI TR-03183-2 v2.1.0**.<br />Only valid for use in `components[]/properties` and `metadata/component/properties`. MUST occur exactly once per component. |
+| **`bsi:component:structured`** | A flag indicating whether the component is a structured file; i.e. metadata of the contents is still present; possible values are `structured` and `unstructured`; see also section 3.2.1 and 5.2.2 of **BSI TR-03183-2 v2.1.0**. If a component contains both structured and unstructured parts the value `structured` MUST be used. For additional explanation see section 8.1.6 of **BSI TR-03183-2 v2.1.0**.<br />Only valid for use in `components[]/properties` and `metadata/component/properties`. MUST occur exactly once per component. |
+| **`bsi:component:filename`** | A field providing the actual filename of the component (i.e. not its path); see also section 5.2.2 of **BSI-TR-03183-2 v2.1.0**. For additional explanation see section 3.2.1 of **BSI TR-03183-2 v2.1.0**.<br />Only valid for use in `components[]/properties` and `metadata/component/properties`. MUST occur at most once per component. |
+| **`bsi:component:effectiveLicence`** | A field providing the effective licence of the component as a single licence identifier or licence expression set by the creator of the current SBOM; see also section 5.2.5 of **BSI TR-03183-2 v2.1.0**. For additional explanation see sections 6.1 and 8.1.13 of **BSI TR-03183-2 v2.1.0**.<br />Only valid for use in `components[]/properties` and `metadata/component/properties`. MUST occur exactly once per component. |
+| **`bsi:component:associatedLicences`**<br />`deprecated` | A field providing the associated licence(s) of the component as a single licence identifier or licence expression from the perspective of the SBOM creator; see also section 5.2.2 of **BSI TR-03183-2 v2.0.0**. For additional explanation see sections 6.1 and 8.1.9 of **BSI TR-03183-2 v2.0.0**.<br />Only valid for use in `components[]/properties` and `metadata/component/properties`. MUST occur exactly once per component. |
 
 ## Contributing
 


### PR DESCRIPTION
With the publication of the BSI TR-03183-2 V2.1.0 some alignment of the BSI CycloneDX Property Taxonomy is needed.